### PR TITLE
support nginx 1.18.0

### DIFF
--- a/src/ngx_http_krisp_module.c
+++ b/src/ngx_http_krisp_module.c
@@ -243,11 +243,19 @@ ngx_http_krisp_realip_handler(ngx_http_request_t *r)
 
         case NGX_HTTP_KRISP_PROXY:
 
+#if nginx_version < 1018000
             value = &r->connection->proxy_protocol_addr;
 
             if (value->len == 0) {
                 return NGX_DECLINED;
             }
+#else
+			if (r->connection->proxy_protocol == NULL) {
+				return NGX_DECLINED;
+			}
+
+			value = &r->connection->proxy_protocol->src_addr;
+#endif
 
             xfwd = NULL;
 


### PR DESCRIPTION
when build on ngnix 1.18.0, occurs follow erros:

```
make -f objs/Makefile
make[1]: Entering directory `/root/rpmbuild/BUILD/aaa'
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -g -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic   -I src/core -I src/event -I src/event/modules -I src/os/unix -I src/http/modules/perl -I /usr/include/krisp -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
        -o objs/addon/src/ngx_http_krisp_module.o \
        nginx-module-krisp/src/ngx_http_krisp_module.c
nginx-module-krisp/src/ngx_http_krisp_module.c: In function 'ngx_http_krisp_realip_handler':
nginx-module-krisp/src/ngx_http_krisp_module.c:246:35: error: 'ngx_connection_t' has no member named 'proxy_protocol_addr'
             value = &r->connection->proxy_protocol_addr;
                                   ^
make[1]: *** [objs/addon/src/ngx_http_krisp_module.o] Error 1
make[1]: Leaving directory `/root/rpmbuild/BUILD/aaa'
make: *** [build] Error 2

``` 